### PR TITLE
Move from skypack to esm.sh

### DIFF
--- a/src/deps.deno.ts
+++ b/src/deps.deno.ts
@@ -1,2 +1,2 @@
 export * from "https://lib.deno.dev/x/grammy@v1/mod.ts";
-export type { Message } from "https://cdn.skypack.dev/@grammyjs/types@v2?dts";
+export type { Message } from "https://esm.sh/@grammyjs/types@v2";


### PR DESCRIPTION
There is a problem with skypack. It seems like it is unable to build the new types dependency. All plugins and grammY are migrating to https://esm.sh now, which does not have the same problem.