### PR TITLE
Issue #13: allowed concatenate custom values

### DIFF
--- a/src/emoji.ts
+++ b/src/emoji.ts
@@ -6,11 +6,11 @@ interface Emoji {
 }
 
 type EmojiList = typeof emojis;
-type EmojiName = keyof EmojiList;
+type EmojiName = keyof EmojiList | (string & {});
 
-function getEmoji(name: EmojiName): Emoji | undefined {
-    const emoji = emojis[name];
-    return emoji ? { name, emoji } : undefined;
+function getEmoji(name: EmojiName): Emoji | string {
+    const emoji = emojis[name as keyof EmojiList];
+    return emoji ? { name, emoji } : name;
 }
 
 export default getEmoji;

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -34,13 +34,11 @@ export type EmojiFlavor<C extends Context = Context> = C & {
 
 function withEmoji(string: TemplateStringsArray, ...emojis: EmojiName[]) {
     return string.reduce((acc, str, index) => {
-        // ! the number of elements in `string` is 1 more than in `emojis`,
-        // ! so we will look for `undefined` emoji, which does not make sense,
-        // ! so we exit the loop early.
+        // The number of elements in `string` is 1 more than in `emojis`, therefore
+        // we will be looking for an `undefined` emoji, which does not make sense,
+        // so we exit the loop early.
         if (index === string.length - 1) return acc + str;
         const emoji = getEmoji(emojis[index]);
-        // ! `emoji` can be a string type if it's a custom value
-        // ! or an object if it's an emoji
         return acc + str + (typeof emoji === "string" ? emoji : emoji.emoji);
     }, "");
 }
@@ -58,7 +56,6 @@ export function emojiParser<C extends EmojiFlavor>() {
 
 export function emoji(name: EmojiName): string {
     const emoji = getEmoji(name);
-    // ! `emoji` can be a string type if it's a custom value
-    // ! or an object if it's an emoji
+    // `emoji` will be `name` if an emoji with that name doesn't exist.
     return typeof emoji === "string" ? emoji : emoji.emoji;
 }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -29,13 +29,19 @@ export type EmojiFlavor<C extends Context = Context> = C & {
     replyWithEmoji: (
         string: TemplateStringsArray,
         ...emojis: EmojiName[]
-    ) => ReturnType<C['reply']>;
+    ) => ReturnType<C["reply"]>;
 };
 
 function withEmoji(string: TemplateStringsArray, ...emojis: EmojiName[]) {
     return string.reduce((acc, str, index) => {
+        // ! the number of elements in `string` is 1 more than in `emojis`,
+        // ! so we will look for `undefined` emoji, which does not make sense,
+        // ! so we exit the loop early.
+        if (index === string.length - 1) return acc + str;
         const emoji = getEmoji(emojis[index]);
-        return acc + str + (emoji ? emoji.emoji : "");
+        // ! `emoji` can be a string type if it's a custom value
+        // ! or an object if it's an emoji
+        return acc + str + (typeof emoji === "string" ? emoji : emoji.emoji);
     }, "");
 }
 
@@ -51,5 +57,8 @@ export function emojiParser<C extends EmojiFlavor>() {
 }
 
 export function emoji(name: EmojiName): string {
-    return getEmoji(name)?.emoji ?? "";
+    const emoji = getEmoji(name);
+    // ! `emoji` can be a string type if it's a custom value
+    // ! or an object if it's an emoji
+    return typeof emoji === "string" ? emoji : emoji.emoji;
 }


### PR DESCRIPTION
The `EmojiName` type can now take any string value, which increases DX by not having to create hard-to-read constructs to concatenate anything that isn't an emoji.
By the way, the `string & {}` construction allows to leave autocompletion working.